### PR TITLE
WIP: Add rule fix_inefficient_use_of_stringbuilder

### DIFF
--- a/src/program.dl
+++ b/src/program.dl
@@ -6,6 +6,7 @@
 #include "rules/fix_inefficient_map_access/implementation.dl"
 #include "rules/fix_null_pointer_exceptions_by_changing_the_order_of_arguments_in_string_comparison/implementation.dl"
 #include "rules/fix_null_returns_in_tostring/implementation.dl"
+#include "rules/fix_inefficient_use_of_stringbuilder/implementation.dl"
 #include "rules/fix_potential_resource_leaks/implementation.dl"
 #include "rules/fix_raw_use_of_empty_collections/implementation.dl"
 #include "rules/fix_raw_use_of_generic_class/implementation.dl"
@@ -237,6 +238,18 @@ string_representation_list(list, substr(code, start, end - start)) :-
         ends_at(last, end),
         filename_of(last, filename),
     source_code(filename, code).
+
+/* Misc
+ ********************************/
+
+.decl method_invocation_root_subject(meth_inv: id, root: id)
+method_invocation_root_subject(meth_inv, subject) :-
+    method_invocation(meth_inv, subject, _, _),
+    !method_invocation(subject, _, _, _).
+method_invocation_root_subject(meth_inv, subject_root) :-
+    method_invocation(meth_inv, subject, _, _),
+    method_invocation(subject, _, _, _),
+    method_invocation_root_subject(subject, subject_root).
 
 /* Variable scope
  ********************************/

--- a/src/rules/fix_inefficient_use_of_stringbuilder/implementation.dl
+++ b/src/rules/fix_inefficient_use_of_stringbuilder/implementation.dl
@@ -1,0 +1,13 @@
+rewrite("fix_inefficient_use_of_stringbuilder", filename, start, end, cat(sub_subject_str, ".toString() + ", str_str)) :-
+    method_invocation(id, subject, "toString", nil),
+        filename_of(id, filename),
+        starts_at(id, start),
+        ends_at(id, end),
+    method_invocation(subject, sub_subject, "append", [str, nil]),
+    has_string_type(str),
+    method_invocation_root_subject(id, root),
+    class_instance_creation_expression(root, nil, nil, type, nil, nil),
+    class_type(type, "StringBuilder", _, _),
+    string_representation(sub_subject, sub_subject_str),
+    string_representation(str, str_str).
+

--- a/src/rules/fix_inefficient_use_of_stringbuilder/tests/Test.java
+++ b/src/rules/fix_inefficient_use_of_stringbuilder/tests/Test.java
@@ -1,0 +1,5 @@
+class Test {
+    void test(String input) {
+        return new StringBuilder().append(" {").append("} ").toString();
+    }
+}


### PR DESCRIPTION
```diff
-      return new StringBuilder()
-         .append('L')
-         .append(valueBuffer, valueBegin, valueEnd)
-         .append(';')
-         .toString();
+     return 'L' + valueBuffer.substring(valueBegin, valueEnd) + ';';
```